### PR TITLE
More configs and CT Integration

### DIFF
--- a/src/main/java/techguns/TGConfig.java
+++ b/src/main/java/techguns/TGConfig.java
@@ -657,6 +657,10 @@ public class TGConfig {
 		@Config.RangeInt(min = 1, max = 256)
 		@Config.LangKey("config.techguns.spawnerBlock.spawnerBlockMaxLinkedMobs")
 		public int spawnerBlockMaxLinkedMobs = 12;
+
+		@Config.Comment("false = default TG mode (spawns only ITGSpawnerNPC mobs from presets). true = custom mode (spawns any EntityLiving from this spawner's mobtypes NBT id; use this when editing spawner NBT to point at entities from other mods).")
+		@Config.LangKey("config.techguns.spawnerBlock.spawnerBlockUseCustomEntitySpawn")
+		public boolean spawnerBlockUseCustomEntitySpawn = false;
 	}
 
 	static {

--- a/src/main/java/techguns/TGConfig.java
+++ b/src/main/java/techguns/TGConfig.java
@@ -631,6 +631,34 @@ public class TGConfig {
 		public float powermult_oil = 0.8f;
 	}
 
+	@Config.Name("Spawner Block")
+	@Config.Comment("Techguns monster spawner blocks (holes / soldier spawns) used in world structures and dungeon presets. Does not change vanilla mob spawners.")
+	@Config.LangKey("config.techguns.spawner_block")
+	public static SpawnerBlock spawnerBlock = new SpawnerBlock();
+
+	public static class SpawnerBlock {
+
+		@Config.Comment("Seconds between spawn attempts for TG spawner tile entities (default worldgen/dungeon tuning).")
+		@Config.RangeInt(min = 1, max = 3600)
+		@Config.LangKey("config.techguns.spawnerBlock.spawnerBlockIntervalSeconds")
+		public int spawnerBlockIntervalSeconds = 25;
+
+		@Config.Comment("Default maximum mobs one spawner may spawn in total before removing itself (used by structure presets and dungeon initSpawner).")
+		@Config.RangeInt(min = 1, max = 64)
+		@Config.LangKey("config.techguns.spawnerBlock.spawnerBlockWorldgenMobsTotal")
+		public int spawnerBlockWorldgenMobsTotal = 2;
+
+		@Config.Comment("Default maximum mobs alive at once per spawner. Should not exceed SpawnerWorldgenMobsTotal.")
+		@Config.RangeInt(min = 1, max = 64)
+		@Config.LangKey("config.techguns.spawnerBlock.spawnerBlockWorldgenMobsConcurrent")
+		public int spawnerBlockWorldgenMobsConcurrent = 2;
+
+		@Config.Comment("Safety cap: maximum mobs linked to one spawner tile in range (prevents pile-ups if something goes wrong).")
+		@Config.RangeInt(min = 1, max = 256)
+		@Config.LangKey("config.techguns.spawnerBlock.spawnerBlockMaxLinkedMobs")
+		public int spawnerBlockMaxLinkedMobs = 12;
+	}
+
 	static {
 		try {
 			Class.forName("com.cleanroommc.configanytime.ConfigAnytime")
@@ -638,6 +666,11 @@ public class TGConfig {
 					.invoke(null, TGConfig.class);
 		} catch (Exception ignored) {
 		}
+	}
+
+	/** Spawn interval for TG spawner blocks, in game ticks (20 ticks = 1 s). */
+	public static int getSpawnerBlockIntervalTicks() {
+		return Math.max(1, spawnerBlock.spawnerBlockIntervalSeconds) * 20;
 	}
 
 	@SubscribeEvent

--- a/src/main/java/techguns/entities/npcs/GenericNPC.java
+++ b/src/main/java/techguns/entities/npcs/GenericNPC.java
@@ -167,7 +167,7 @@ public class GenericNPC extends EntityMob implements IRangedAttackMob, INPCTechg
 	@Override
 	protected void setEquipmentBasedOnDifficulty(DifficultyInstance difficulty) {
 		int d = Math.round(difficulty.getClampedAdditionalDifficulty()*3f);
-		this.addRandomArmor(d);
+		this.addRandomArmorIfEmpty(d);
 	}
 	    
 	    
@@ -182,8 +182,22 @@ public class GenericNPC extends EntityMob implements IRangedAttackMob, INPCTechg
 
 	public void onSpawnByManager(int difficulty) {
 	    this.setCanPickUpLoot(false);
-		this.addRandomArmor(difficulty);
+		this.addRandomArmorIfEmpty(difficulty);
 		this.setCombatTask();
+	}
+
+	/**
+	 * Applies random armor only if all armor slots are empty
+	 * (e.g. no preset armor provided via NBT).
+	 */
+	protected void addRandomArmorIfEmpty(int difficulty) {
+		for (EntityEquipmentSlot slot : EntityEquipmentSlot.values()) {
+			if (slot.getSlotType() == EntityEquipmentSlot.Type.ARMOR && !this.getItemStackFromSlot(slot).isEmpty()) {
+				return;
+			}
+		}
+
+		this.addRandomArmor(difficulty);
 	}
 	    
 	    

--- a/src/main/java/techguns/items/armors/GenericArmor.java
+++ b/src/main/java/techguns/items/armors/GenericArmor.java
@@ -179,6 +179,11 @@ public class GenericArmor extends ItemArmor implements ISpecialArmor, IItemTGRen
         return this;
     }
 
+    public GenericArmor setArmorDisplayValue(int value) {
+        this.armorValue = Math.max(0, value);
+        return this;
+    }
+
     public GenericArmor setKnockbackResistance(float resistpercent) {
         this.knockbackresistance = resistpercent;
         return this;
@@ -402,6 +407,15 @@ public class GenericArmor extends ItemArmor implements ISpecialArmor, IItemTGRen
 
     public float getArmorValue(DamageType type) {
         return this.material.getArmorValueSlot(armorType, type);
+    }
+
+    public TGArmorMaterial getTGArmorMaterial() {
+        return this.material;
+    }
+
+    public void refreshMaterialDerivedStats() {
+        this.armorValue = Math.round(this.material.getArmorValueSlot(this.armorType, DamageType.PHYSICAL));
+        this.setMaxDamage(this.material.getDurability(this.armorType));
     }
 
     public float getToughness() {

--- a/src/main/java/techguns/items/armors/TGArmorMaterial.java
+++ b/src/main/java/techguns/items/armors/TGArmorMaterial.java
@@ -201,6 +201,37 @@ public class TGArmorMaterial {
         return toughness;
     }
 
+    public TGArmorMaterial setToughness(float toughness) {
+        this.toughness = Math.max(0.0f, toughness);
+        return this;
+    }
+
+    public TGArmorMaterial setBaseDurability(int baseDurability) {
+        this.baseDur = Math.max(1, baseDurability);
+        return this;
+    }
+
+    public TGArmorMaterial setDurabilityFactor(EntityEquipmentSlot slot, float factor) {
+        float clamped = Math.max(0.0f, factor);
+        switch (slot) {
+            case HEAD:
+                this.durHead = clamped;
+                break;
+            case CHEST:
+                this.durChest = clamped;
+                break;
+            case LEGS:
+                this.durLegs = clamped;
+                break;
+            case FEET:
+                this.durBoots = clamped;
+                break;
+            default:
+                break;
+        }
+        return this;
+    }
+
     public void setArmorValueForType(DamageType type, float value) {
         switch (type) {
             case DARK:

--- a/src/main/java/techguns/items/guns/GenericGun.java
+++ b/src/main/java/techguns/items/guns/GenericGun.java
@@ -1615,6 +1615,18 @@ public class GenericGun extends GenericItem implements IGenericGun, IItemTGRende
                 this.gravity = value;
                 yield true;
             }
+            case MINING_SPEED -> {
+                this.digSpeed = value;
+                yield true;
+            }
+            case MIN_FIRE_TIME -> {
+                this.minFiretime = Math.max(0, (int) value);
+                yield true;
+            }
+            case ACCURACY -> {
+                this.accuracy = value;
+                yield true;
+            }
             case SPREAD -> {
                 this.spread = value;
                 yield true;
@@ -1624,7 +1636,8 @@ public class GenericGun extends GenericItem implements IGenericGun, IItemTGRende
                 yield true;
             }
             case CLIP_SIZE -> {
-                this.clipsize = (int) value;
+                this.clipsize = Math.max(1, (int) value);
+                this.setMaxDamage(this.clipsize);
                 yield true;
             }
             case AMMO_COUNT -> {

--- a/src/main/java/techguns/plugins/crafttweaker/ArmorStatTweaker.java
+++ b/src/main/java/techguns/plugins/crafttweaker/ArmorStatTweaker.java
@@ -2,7 +2,11 @@ package techguns.plugins.crafttweaker;
 
 import crafttweaker.CraftTweakerAPI;
 import crafttweaker.IAction;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import stanhebben.zenscript.annotations.ZenClass;
@@ -32,6 +36,108 @@ public class ArmorStatTweaker {
 	public static void setMaterialArmorValue(String material, String damagetype, float amount) {
 		CraftTweakerAPI.apply(new setArmorMaterialValue(material, damagetype, amount));
 	}
+
+	@ZenMethod
+	public static void setArmorDurability(String armorname, int durability) {
+		CraftTweakerAPI.apply(new setArmorDurabilityAction(armorname, durability));
+	}
+
+	@ZenMethod
+	public static void setArmorDisplayValue(String armorname, int value) {
+		CraftTweakerAPI.apply(new setArmorDisplayValueAction(armorname, value));
+	}
+
+	@ZenMethod
+	public static void setMaterialBaseDurability(String material, int baseDurability) {
+		CraftTweakerAPI.apply(new setArmorMaterialBaseDurabilityAction(material, baseDurability));
+	}
+
+	@ZenMethod
+	public static void setMaterialDurabilityFactor(String material, String slot, float factor) {
+		CraftTweakerAPI.apply(new setArmorMaterialDurabilityFactorAction(material, slot, factor));
+	}
+
+	@ZenMethod
+	public static void setMaterialToughness(String material, float amount) {
+		CraftTweakerAPI.apply(new setArmorMaterialToughnessAction(material, amount));
+	}
+
+	@ZenMethod
+	public static void setArmorKnockbackResistance(String armorname, float value) {
+		CraftTweakerAPI.apply(new setArmorKnockbackResistanceAction(armorname, value));
+	}
+
+	@ZenMethod
+	public static void setArmorRadResistance(String armorname, float value) {
+		CraftTweakerAPI.apply(new setArmorRadResistanceAction(armorname, value));
+	}
+
+	@ZenMethod
+	public static void setArmorHiddenSlots(String armorname, boolean hideFace, boolean hideBack, boolean hideGlove) {
+		CraftTweakerAPI.apply(new setArmorHiddenSlotsAction(armorname, hideFace, hideBack, hideGlove));
+	}
+
+	@ZenMethod
+	public static void setArmorRepairMats(String armorname, IItemStack metal, IItemStack cloth, float metalPercent, int totalMats) {
+		CraftTweakerAPI.apply(new setArmorRepairMatsAction(armorname, metal, cloth, metalPercent, totalMats));
+	}
+
+	@ZenMethod
+	public static void setPoweredArmorMaxPower(String armorname, int maxPower) {
+		CraftTweakerAPI.apply(new setPoweredArmorMaxPowerAction(armorname, maxPower));
+	}
+
+	@ZenMethod
+	public static void setPoweredArmorBattery(String armorname, IItemStack battery) {
+		CraftTweakerAPI.apply(new setPoweredArmorBatteryAction(armorname, battery, null));
+	}
+
+	@ZenMethod
+	public static void setPoweredArmorBattery(String armorname, IItemStack battery, IItemStack emptyBattery) {
+		CraftTweakerAPI.apply(new setPoweredArmorBatteryAction(armorname, battery, emptyBattery));
+	}
+
+	private static GenericArmor getArmor(String armorname) {
+		Item item = GameRegistry.findRegistry(Item.class).getValue(new ResourceLocation(Tags.MOD_ID, armorname));
+		if (item instanceof GenericArmor) {
+			return (GenericArmor) item;
+		}
+		return null;
+	}
+
+	private static PoweredArmor getPoweredArmor(String armorname) {
+		Item item = GameRegistry.findRegistry(Item.class).getValue(new ResourceLocation(Tags.MOD_ID, armorname));
+		if (item instanceof PoweredArmor) {
+			return (PoweredArmor) item;
+		}
+		return null;
+	}
+
+	private static TGArmorMaterial getArmorMaterial(String materialname) {
+		for (TGArmorMaterial mat : TGArmorMaterial.MATERIALS) {
+			if (mat.name.equalsIgnoreCase(materialname)) {
+				return mat;
+			}
+		}
+		return null;
+	}
+
+	private static void refreshArmorsForMaterial(TGArmorMaterial material) {
+		for (GenericArmor armor : TGArmors.armors) {
+			if (armor.getTGArmorMaterial() == material) {
+				armor.refreshMaterialDerivedStats();
+			}
+		}
+	}
+
+	private static EntityEquipmentSlot parseArmorSlot(String slotname) {
+		for (EntityEquipmentSlot slot : new EntityEquipmentSlot[]{EntityEquipmentSlot.HEAD, EntityEquipmentSlot.CHEST, EntityEquipmentSlot.LEGS, EntityEquipmentSlot.FEET}) {
+			if (slot.name().equalsIgnoreCase(slotname)) {
+				return slot;
+			}
+		}
+		return null;
+	}
 	
 	
 	private static class setArmorMaterialValue implements IAction {
@@ -55,20 +161,15 @@ public class ArmorStatTweaker {
 					break;
 				}
 			}
-			
-			for(TGArmorMaterial mat: TGArmorMaterial.MATERIALS) {
-				if(mat.name.equalsIgnoreCase(materialname)) {
-					this.material=mat;
-					break;
-				}
-			}
-			
+
+			this.material = getArmorMaterial(materialname);
 		}
 
 		@Override
 		public void apply() {
 			if(this.material!=null && this.type!=null) {
 				this.material.setArmorValueForType(type, value);
+				refreshArmorsForMaterial(this.material);
 			}
 		}
 
@@ -84,6 +185,335 @@ public class ArmorStatTweaker {
 			return "Set ArmorValue ["+typename+"] for Material: ["+materialname+"] to: "+value;
 		}
 		
+	}
+
+	private static class setArmorDurabilityAction implements IAction {
+		protected String armorname;
+		protected int durability;
+		protected GenericArmor armor;
+
+		public setArmorDurabilityAction(String armorname, int durability) {
+			this.armorname = armorname;
+			this.durability = Math.max(1, durability);
+			this.armor = getArmor(armorname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.armor != null) {
+				this.armor.setDurability(this.durability);
+			}
+		}
+
+		@Override
+		public String describe() {
+			if (this.armor == null) {
+				return "Failed setting durability for Armor: [" + armorname + "]: ITEM IS NOT A TECHGUNS ARMOR";
+			}
+			return "Set durability for Armor: [" + armorname + "] to: " + durability;
+		}
+	}
+
+	private static class setArmorDisplayValueAction implements IAction {
+		protected String armorname;
+		protected int value;
+		protected GenericArmor armor;
+
+		public setArmorDisplayValueAction(String armorname, int value) {
+			this.armorname = armorname;
+			this.value = Math.max(0, value);
+			this.armor = getArmor(armorname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.armor != null) {
+				this.armor.setArmorDisplayValue(this.value);
+			}
+		}
+
+		@Override
+		public String describe() {
+			if (this.armor == null) {
+				return "Failed setting display armor value for Armor: [" + armorname + "]: ITEM IS NOT A TECHGUNS ARMOR";
+			}
+			return "Set display armor value for Armor: [" + armorname + "] to: " + value;
+		}
+	}
+
+	private static class setArmorMaterialBaseDurabilityAction implements IAction {
+		protected String materialname;
+		protected int baseDurability;
+		protected TGArmorMaterial material;
+
+		public setArmorMaterialBaseDurabilityAction(String materialname, int baseDurability) {
+			this.materialname = materialname;
+			this.baseDurability = Math.max(1, baseDurability);
+			this.material = getArmorMaterial(materialname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.material != null) {
+				this.material.setBaseDurability(this.baseDurability);
+				refreshArmorsForMaterial(this.material);
+			}
+		}
+
+		@Override
+		public String describe() {
+			if (this.material == null) {
+				return "Failed setting base durability for Material: [" + materialname + "]: MATERIAL DOES NOT EXIST!";
+			}
+			return "Set base durability for Material: [" + materialname + "] to: " + baseDurability;
+		}
+	}
+
+	private static class setArmorMaterialDurabilityFactorAction implements IAction {
+		protected String materialname;
+		protected String slotname;
+		protected float factor;
+		protected TGArmorMaterial material;
+		protected EntityEquipmentSlot slot;
+
+		public setArmorMaterialDurabilityFactorAction(String materialname, String slotname, float factor) {
+			this.materialname = materialname;
+			this.slotname = slotname;
+			this.factor = Math.max(0.0f, factor);
+			this.material = getArmorMaterial(materialname);
+			this.slot = parseArmorSlot(slotname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.material != null && this.slot != null) {
+				this.material.setDurabilityFactor(this.slot, this.factor);
+				refreshArmorsForMaterial(this.material);
+			}
+		}
+
+		@Override
+		public String describe() {
+			if (this.material == null) {
+				return "Failed setting durability factor for Material: [" + materialname + "]: MATERIAL DOES NOT EXIST!";
+			}
+			if (this.slot == null) {
+				return "Failed setting durability factor for Material: [" + materialname + "]: UNKNOWN SLOT [" + slotname + "]";
+			}
+			return "Set durability factor for Material: [" + materialname + "] slot [" + slotname + "] to: " + factor;
+		}
+	}
+
+	private static class setArmorMaterialToughnessAction implements IAction {
+		protected String materialname;
+		protected float toughness;
+		protected TGArmorMaterial material;
+
+		public setArmorMaterialToughnessAction(String materialname, float toughness) {
+			this.materialname = materialname;
+			this.toughness = Math.max(0.0f, toughness);
+			this.material = getArmorMaterial(materialname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.material != null) {
+				this.material.setToughness(this.toughness);
+			}
+		}
+
+		@Override
+		public String describe() {
+			if (this.material == null) {
+				return "Failed setting toughness for Material: [" + materialname + "]: MATERIAL DOES NOT EXIST!";
+			}
+			return "Set toughness for Material: [" + materialname + "] to: " + toughness;
+		}
+	}
+
+	private static class setArmorKnockbackResistanceAction implements IAction {
+		protected String armorname;
+		protected float value;
+		protected GenericArmor armor;
+
+		public setArmorKnockbackResistanceAction(String armorname, float value) {
+			this.armorname = armorname;
+			this.value = value;
+			this.armor = getArmor(armorname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.armor != null) {
+				this.armor.setKnockbackResistance(this.value);
+			}
+		}
+
+		@Override
+		public String describe() {
+			if (this.armor == null) {
+				return "Failed setting knockback resistance for Armor: [" + armorname + "]: ITEM IS NOT A TECHGUNS ARMOR";
+			}
+			return "Set knockback resistance for Armor: [" + armorname + "] to: " + value;
+		}
+	}
+
+	private static class setArmorRadResistanceAction implements IAction {
+		protected String armorname;
+		protected float value;
+		protected GenericArmor armor;
+
+		public setArmorRadResistanceAction(String armorname, float value) {
+			this.armorname = armorname;
+			this.value = value;
+			this.armor = getArmor(armorname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.armor != null) {
+				this.armor.setRADResistance(this.value);
+			}
+		}
+
+		@Override
+		public String describe() {
+			if (this.armor == null) {
+				return "Failed setting radiation resistance for Armor: [" + armorname + "]: ITEM IS NOT A TECHGUNS ARMOR";
+			}
+			return "Set radiation resistance for Armor: [" + armorname + "] to: " + value;
+		}
+	}
+
+	private static class setArmorHiddenSlotsAction implements IAction {
+		protected String armorname;
+		protected boolean hideFace;
+		protected boolean hideBack;
+		protected boolean hideGlove;
+		protected GenericArmor armor;
+
+		public setArmorHiddenSlotsAction(String armorname, boolean hideFace, boolean hideBack, boolean hideGlove) {
+			this.armorname = armorname;
+			this.hideFace = hideFace;
+			this.hideBack = hideBack;
+			this.hideGlove = hideGlove;
+			this.armor = getArmor(armorname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.armor != null) {
+				this.armor.setHideFaceslot(this.hideFace);
+				this.armor.setHideBackslot(this.hideBack);
+				this.armor.setHideGloveslot(this.hideGlove);
+			}
+		}
+
+		@Override
+		public String describe() {
+			if (this.armor == null) {
+				return "Failed setting hidden slots for Armor: [" + armorname + "]: ITEM IS NOT A TECHGUNS ARMOR";
+			}
+			return "Set hidden slots for Armor: [" + armorname + "] to face/back/glove = " + hideFace + "/" + hideBack + "/" + hideGlove;
+		}
+	}
+
+	private static class setArmorRepairMatsAction implements IAction {
+		protected String armorname;
+		protected ItemStack metal;
+		protected ItemStack cloth;
+		protected float metalPercent;
+		protected int totalMats;
+		protected GenericArmor armor;
+
+		public setArmorRepairMatsAction(String armorname, IItemStack metal, IItemStack cloth, float metalPercent, int totalMats) {
+			this.armorname = armorname;
+			this.metal = CraftTweakerMC.getItemStack(metal);
+			this.cloth = CraftTweakerMC.getItemStack(cloth);
+			this.metalPercent = MathUtil.clamp(metalPercent, 0.0f, 1.0f);
+			this.totalMats = Math.max(0, totalMats);
+			this.armor = getArmor(armorname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.armor != null) {
+				this.armor.setRepairMats(this.metal, this.cloth, this.metalPercent, this.totalMats);
+			}
+		}
+
+		@Override
+		public String describe() {
+			if (this.armor == null) {
+				return "Failed setting repair mats for Armor: [" + armorname + "]: ITEM IS NOT A TECHGUNS ARMOR";
+			}
+			return "Set repair mats for Armor: [" + armorname + "]";
+		}
+	}
+
+	private static class setPoweredArmorMaxPowerAction implements IAction {
+		protected String armorname;
+		protected int maxPower;
+		protected PoweredArmor armor;
+
+		public setPoweredArmorMaxPowerAction(String armorname, int maxPower) {
+			this.armorname = armorname;
+			this.maxPower = Math.max(1, maxPower);
+			this.armor = getPoweredArmor(armorname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.armor != null) {
+				this.armor.maxpower = this.maxPower;
+			}
+		}
+
+		@Override
+		public String describe() {
+			if (this.armor == null) {
+				return "Failed setting max power for Armor: [" + armorname + "]: ITEM IS NOT A POWERED ARMOR";
+			}
+			return "Set max power for Armor: [" + armorname + "] to: " + maxPower;
+		}
+	}
+
+	private static class setPoweredArmorBatteryAction implements IAction {
+		protected String armorname;
+		protected ItemStack battery;
+		protected ItemStack emptyBattery;
+		protected boolean hasEmptyBattery;
+		protected PoweredArmor armor;
+
+		public setPoweredArmorBatteryAction(String armorname, IItemStack battery, IItemStack emptyBattery) {
+			this.armorname = armorname;
+			this.battery = CraftTweakerMC.getItemStack(battery);
+			this.hasEmptyBattery = emptyBattery != null;
+			if (this.hasEmptyBattery) {
+				this.emptyBattery = CraftTweakerMC.getItemStack(emptyBattery);
+			} else {
+				this.emptyBattery = ItemStack.EMPTY;
+			}
+			this.armor = getPoweredArmor(armorname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.armor != null) {
+				this.armor.setBattery(this.battery);
+				if (this.hasEmptyBattery) {
+					this.armor.setEmptyBattery(this.emptyBattery);
+				}
+			}
+		}
+
+		@Override
+		public String describe() {
+			if (this.armor == null) {
+				return "Failed setting battery for Armor: [" + armorname + "]: ITEM IS NOT A POWERED ARMOR";
+			}
+			return "Set battery settings for Armor: [" + armorname + "]";
+		}
 	}
 	
 	private static class setArmorStatAction implements IAction {
@@ -108,8 +538,8 @@ public class ArmorStatTweaker {
 			this.statname = statname;
 			this.value = value;
 			this.value_unpowered = value_unpowered;
-			
-			Item item = GameRegistry.findRegistry(Item.class).getValue(new ResourceLocation(Tags.MOD_ID, armorname));
+
+			Item item = getArmor(armorname);
 			this.stat = EnumArmorStat.parseFromString(statname);
 		
 

--- a/src/main/java/techguns/plugins/crafttweaker/EnumGunStat.java
+++ b/src/main/java/techguns/plugins/crafttweaker/EnumGunStat.java
@@ -34,7 +34,15 @@ public enum EnumGunStat {
 	 */
 	MINING_SPEED,
 	/**
-	 * How much shots randomly divert
+	 * Minimum time between shots in ticks
+	 */
+	MIN_FIRE_TIME,
+	/**
+	 * Random spread for regular single-projectile shots
+	 */
+	ACCURACY,
+	/**
+	 * Random spread for shotgun/burst projectiles
 	 */
 	SPREAD,
 	PENETRATION,
@@ -44,8 +52,9 @@ public enum EnumGunStat {
 	RELOAD_TIME;
 	
 	public static EnumGunStat parseFromString(String s) {
-		for(EnumGunStat e :EnumGunStat.values()) {
-			if(e.name().equalsIgnoreCase(s)) {
+		String normalized = s.replace("_", "");
+		for (EnumGunStat e : EnumGunStat.values()) {
+			if (e.name().equalsIgnoreCase(s) || e.name().replace("_", "").equalsIgnoreCase(normalized)) {
 				return e;
 			}
 		}

--- a/src/main/java/techguns/plugins/crafttweaker/GunStatTweaker.java
+++ b/src/main/java/techguns/plugins/crafttweaker/GunStatTweaker.java
@@ -8,6 +8,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 import techguns.*;
+import techguns.api.guns.GunHandType;
 import techguns.items.guns.GenericGun;
 
 @ZenClass("mods.techguns.GunStats")
@@ -16,6 +17,78 @@ public class GunStatTweaker {
 	@ZenMethod
 	public static void setWeaponStat(String weaponname, String fieldname, float value) {
 		CraftTweakerAPI.apply(new setGunStatAction(weaponname, fieldname, value));
+	}
+
+	@ZenMethod
+	public static void setWeaponDamageDrop(String weaponname, float start, float end, float minDamage) {
+		CraftTweakerAPI.apply(new setWeaponDamageDropAction(weaponname, start, end, minDamage));
+	}
+
+	@ZenMethod
+	public static void setWeaponDamageDrop(String weaponname, double start, double end, double minDamage) {
+		setWeaponDamageDrop(weaponname, (float) start, (float) end, (float) minDamage);
+	}
+
+	@ZenMethod
+	public static void setWeaponZoom(String weaponname, float zoomMult, boolean toggleZoom, float zoomSpreadMultiplier, boolean fireCenteredZoomed) {
+		CraftTweakerAPI.apply(new setWeaponZoomAction(weaponname, zoomMult, toggleZoom, zoomSpreadMultiplier, fireCenteredZoomed));
+	}
+
+	@ZenMethod
+	public static void setWeaponZoom(String weaponname, double zoomMult, boolean toggleZoom, double zoomSpreadMultiplier, boolean fireCenteredZoomed) {
+		setWeaponZoom(weaponname, (float) zoomMult, toggleZoom, (float) zoomSpreadMultiplier, fireCenteredZoomed);
+	}
+
+	@ZenMethod
+	public static void setWeaponShotgunSpread(String weaponname, int bulletCount, float spread, boolean burst) {
+		CraftTweakerAPI.apply(new setWeaponShotgunSpreadAction(weaponname, bulletCount, spread, burst));
+	}
+
+	@ZenMethod
+	public static void setWeaponShotgunSpread(String weaponname, int bulletCount, double spread, boolean burst) {
+		setWeaponShotgunSpread(weaponname, bulletCount, (float) spread, burst);
+	}
+
+	@ZenMethod
+	public static void setWeaponSilenced(String weaponname, boolean value) {
+		CraftTweakerAPI.apply(new setWeaponSilencedAction(weaponname, value));
+	}
+
+	@ZenMethod
+	public static void setWeaponShootWithLeftClick(String weaponname, boolean value) {
+		CraftTweakerAPI.apply(new setWeaponShootWithLeftClickAction(weaponname, value));
+	}
+
+	@ZenMethod
+	public static void setWeaponHandType(String weaponname, String handType) {
+		CraftTweakerAPI.apply(new setWeaponHandTypeAction(weaponname, handType));
+	}
+
+	@ZenMethod
+	public static void setWeaponAIStats(String weaponname, float attackRange, int attackTime, int burstCount, int burstAttackTime) {
+		CraftTweakerAPI.apply(new setWeaponAIStatsAction(weaponname, attackRange, attackTime, burstCount, burstAttackTime));
+	}
+
+	@ZenMethod
+	public static void setWeaponAIStats(String weaponname, double attackRange, int attackTime, int burstCount, int burstAttackTime) {
+		setWeaponAIStats(weaponname, (float) attackRange, attackTime, burstCount, burstAttackTime);
+	}
+
+	private static GenericGun getGun(String weaponname) {
+		Item item = GameRegistry.findRegistry(Item.class).getValue(new ResourceLocation(Tags.MOD_ID, weaponname));
+		if (item instanceof GenericGun) {
+			return (GenericGun) item;
+		}
+		return null;
+	}
+
+	private static GunHandType parseHandType(String handType) {
+		for (GunHandType type : GunHandType.values()) {
+			if (type.name().equalsIgnoreCase(handType)) {
+				return type;
+			}
+		}
+		return null;
 	}
 	
 	private static class setGunStatAction implements IAction {
@@ -32,7 +105,7 @@ public class GunStatTweaker {
 		public setGunStatAction(String weaponname, String fieldname, float value) {
 			this.fieldname=fieldname;
 			this.weaponname=weaponname;
-			Item item = GameRegistry.findRegistry(Item.class).getValue(new ResourceLocation(Tags.MOD_ID, weaponname));
+			Item item = getGun(weaponname);
 			this.field = EnumGunStat.parseFromString(fieldname);
 			this.value = value;
 
@@ -59,5 +132,213 @@ public class GunStatTweaker {
 			return "Set ["+fieldname+"] for Weapon: ["+weaponname+"] to: "+value;
 		}
 		
+	}
+
+	private static class setWeaponDamageDropAction implements IAction {
+		protected String weaponname;
+		protected float start;
+		protected float end;
+		protected float minDamage;
+		protected GenericGun gun;
+
+		public setWeaponDamageDropAction(String weaponname, float start, float end, float minDamage) {
+			this.weaponname = weaponname;
+			this.start = start;
+			this.end = end;
+			this.minDamage = minDamage;
+			this.gun = getGun(weaponname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.gun != null) {
+				this.gun.setDamageDrop(this.start, this.end, this.minDamage);
+			}
+		}
+
+		@Override
+		public String describe() {
+			return this.gun == null
+					? "Failed setting damage drop for Weapon: [" + weaponname + "]: ITEM IS NOT A GUN"
+					: "Set damage drop for Weapon: [" + weaponname + "]";
+		}
+	}
+
+	private static class setWeaponZoomAction implements IAction {
+		protected String weaponname;
+		protected float zoomMult;
+		protected boolean toggleZoom;
+		protected float zoomSpreadMultiplier;
+		protected boolean fireCenteredZoomed;
+		protected GenericGun gun;
+
+		public setWeaponZoomAction(String weaponname, float zoomMult, boolean toggleZoom, float zoomSpreadMultiplier, boolean fireCenteredZoomed) {
+			this.weaponname = weaponname;
+			this.zoomMult = zoomMult;
+			this.toggleZoom = toggleZoom;
+			this.zoomSpreadMultiplier = zoomSpreadMultiplier;
+			this.fireCenteredZoomed = fireCenteredZoomed;
+			this.gun = getGun(weaponname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.gun != null) {
+				this.gun.setZoom(this.zoomMult, this.toggleZoom, this.zoomSpreadMultiplier, this.fireCenteredZoomed);
+			}
+		}
+
+		@Override
+		public String describe() {
+			return this.gun == null
+					? "Failed setting zoom for Weapon: [" + weaponname + "]: ITEM IS NOT A GUN"
+					: "Set zoom for Weapon: [" + weaponname + "]";
+		}
+	}
+
+	private static class setWeaponShotgunSpreadAction implements IAction {
+		protected String weaponname;
+		protected int bulletCount;
+		protected float spread;
+		protected boolean burst;
+		protected GenericGun gun;
+
+		public setWeaponShotgunSpreadAction(String weaponname, int bulletCount, float spread, boolean burst) {
+			this.weaponname = weaponname;
+			this.bulletCount = bulletCount;
+			this.spread = spread;
+			this.burst = burst;
+			this.gun = getGun(weaponname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.gun != null) {
+				this.gun.setShotgunSpread(this.bulletCount, this.spread, this.burst);
+			}
+		}
+
+		@Override
+		public String describe() {
+			return this.gun == null
+					? "Failed setting shotgun spread for Weapon: [" + weaponname + "]: ITEM IS NOT A GUN"
+					: "Set shotgun spread for Weapon: [" + weaponname + "]";
+		}
+	}
+
+	private static class setWeaponSilencedAction implements IAction {
+		protected String weaponname;
+		protected boolean value;
+		protected GenericGun gun;
+
+		public setWeaponSilencedAction(String weaponname, boolean value) {
+			this.weaponname = weaponname;
+			this.value = value;
+			this.gun = getGun(weaponname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.gun != null) {
+				this.gun.setSilenced(this.value);
+			}
+		}
+
+		@Override
+		public String describe() {
+			return this.gun == null
+					? "Failed setting silenced for Weapon: [" + weaponname + "]: ITEM IS NOT A GUN"
+					: "Set silenced for Weapon: [" + weaponname + "] to: " + value;
+		}
+	}
+
+	private static class setWeaponShootWithLeftClickAction implements IAction {
+		protected String weaponname;
+		protected boolean value;
+		protected GenericGun gun;
+
+		public setWeaponShootWithLeftClickAction(String weaponname, boolean value) {
+			this.weaponname = weaponname;
+			this.value = value;
+			this.gun = getGun(weaponname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.gun != null) {
+				this.gun.setShootWithLeftClick(this.value);
+			}
+		}
+
+		@Override
+		public String describe() {
+			return this.gun == null
+					? "Failed setting left-click mode for Weapon: [" + weaponname + "]: ITEM IS NOT A GUN"
+					: "Set left-click mode for Weapon: [" + weaponname + "] to: " + value;
+		}
+	}
+
+	private static class setWeaponHandTypeAction implements IAction {
+		protected String weaponname;
+		protected String handTypeName;
+		protected GenericGun gun;
+		protected GunHandType handType;
+
+		public setWeaponHandTypeAction(String weaponname, String handTypeName) {
+			this.weaponname = weaponname;
+			this.handTypeName = handTypeName;
+			this.gun = getGun(weaponname);
+			this.handType = parseHandType(handTypeName);
+		}
+
+		@Override
+		public void apply() {
+			if (this.gun != null && this.handType != null) {
+				this.gun.setHandType(this.handType);
+			}
+		}
+
+		@Override
+		public String describe() {
+			if (this.gun == null) {
+				return "Failed setting hand type for Weapon: [" + weaponname + "]: ITEM IS NOT A GUN";
+			}
+			if (this.handType == null) {
+				return "Failed setting hand type for Weapon: [" + weaponname + "]: UNKNOWN HAND TYPE";
+			}
+			return "Set hand type for Weapon: [" + weaponname + "] to: " + handTypeName;
+		}
+	}
+
+	private static class setWeaponAIStatsAction implements IAction {
+		protected String weaponname;
+		protected float attackRange;
+		protected int attackTime;
+		protected int burstCount;
+		protected int burstAttackTime;
+		protected GenericGun gun;
+
+		public setWeaponAIStatsAction(String weaponname, float attackRange, int attackTime, int burstCount, int burstAttackTime) {
+			this.weaponname = weaponname;
+			this.attackRange = attackRange;
+			this.attackTime = attackTime;
+			this.burstCount = burstCount;
+			this.burstAttackTime = burstAttackTime;
+			this.gun = getGun(weaponname);
+		}
+
+		@Override
+		public void apply() {
+			if (this.gun != null) {
+				this.gun.setAIStats(this.attackRange, this.attackTime, this.burstCount, this.burstAttackTime);
+			}
+		}
+
+		@Override
+		public String describe() {
+			return this.gun == null
+					? "Failed setting AI stats for Weapon: [" + weaponname + "]: ITEM IS NOT A GUN"
+					: "Set AI stats for Weapon: [" + weaponname + "]";
+		}
 	}
 }

--- a/src/main/java/techguns/tileentities/MetalPressTileEnt.java
+++ b/src/main/java/techguns/tileentities/MetalPressTileEnt.java
@@ -258,8 +258,17 @@ public class MetalPressTileEnt extends BasicMachineTileEnt {
         int required2 = matchedRecipe.input2Count;
 
         int maxMultiplier = this.getMaxMachineUpgradeMultiplier(SLOT_UPGRADE);
-        int possibleMult = Math.min(stackInput1.getCount() / required1, stackInput2.getCount() / required2);
-        int multiplier = Math.min(possibleMult, maxMultiplier);
+        int inputMultiplier = Math.min(stackInput1.getCount() / required1, stackInput2.getCount() / required2);
+        int outputMultiplier = 1;
+        ItemStack stackInOutputSlot = this.inventory.getStackInSlot(SLOT_OUTPUT);
+        if (stackInOutputSlot.isEmpty()) {
+            outputMultiplier = this.inventory.getSlotLimit(SLOT_OUTPUT) / output.getCount();
+        } else if (stackInOutputSlot.isItemEqual(output)) {
+            outputMultiplier = (stackInOutputSlot.getMaxStackSize() - stackInOutputSlot.getCount()) / output.getCount();
+        }
+
+        int ioMultiplier = Math.min(inputMultiplier, outputMultiplier);
+        int multiplier = Math.min(ioMultiplier, maxMultiplier);
 
         if (requiresSteam && matchedRecipe.steamCost > 0) {
             int availableSteam = this.steamTank.getFluidAmount();

--- a/src/main/java/techguns/tileentities/TGSpawnerTileEnt.java
+++ b/src/main/java/techguns/tileentities/TGSpawnerTileEnt.java
@@ -2,6 +2,7 @@ package techguns.tileentities;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityCreature;
+import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.inventory.EntityEquipmentSlot;
@@ -22,6 +23,7 @@ import techguns.capabilities.TGSpawnerNPCData;
 import techguns.entities.npcs.ITGSpawnerNPC;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class TGSpawnerTileEnt extends BasicTGTileEntity implements ITickable {
     /**
@@ -176,6 +178,31 @@ public class TGSpawnerTileEnt extends BasicTGTileEntity implements ITickable {
         return this.mobtypes.size() > 0;
     }
 
+    protected int getCurrentActiveCount() {
+        if (!TGConfig.spawnerBlock.spawnerBlockUseCustomEntitySpawn) {
+            return this.activeMobs.size();
+        }
+        BlockPos pos = this.getPos();
+        AxisAlignedBB area = new AxisAlignedBB(pos).grow(SPAWNER_MOB_COUNT_RADIUS_BLOCKS);
+        Set<String> entityIds = this.mobtypes.stream()
+                .map(WeightedSpawnerEntity::getNbt)
+                .map(nbt -> nbt.getString("id"))
+                .filter(id -> !id.isEmpty())
+                .collect(Collectors.toSet());
+        if (entityIds.isEmpty()) {
+            return 0;
+        }
+        return this.world.getEntitiesWithinAABB(EntityLiving.class, area, e -> {
+            if (e instanceof ITGSpawnerNPC) {
+                TGSpawnerNPCData dat = TGSpawnerNPCData.get((ITGSpawnerNPC) e);
+                if (dat != null && pos.equals(dat.getSpawnerPos())) {
+                    return true;
+                }
+            }
+            return EntityList.getKey(e) != null && entityIds.contains(EntityList.getKey(e).toString());
+        }).size();
+    }
+
     protected boolean hasTooManyNearbySpawnerMobs() {
         BlockPos pos = this.getPos();
         AxisAlignedBB area = new AxisAlignedBB(pos).grow(SPAWNER_MOB_COUNT_RADIUS_BLOCKS);
@@ -193,7 +220,7 @@ public class TGSpawnerTileEnt extends BasicTGTileEntity implements ITickable {
     public void update() {
         if (this.world.isRemote) return;
         this.delay--;
-        if (this.delay <= 0 && activeMobs.size() < Math.min(maxActive, mobsLeft) && this.hasMobTypes() && !this.hasTooManyNearbySpawnerMobs()) {
+        if (this.delay <= 0 && this.getCurrentActiveCount() < Math.min(maxActive, mobsLeft) && this.hasMobTypes() && !this.hasTooManyNearbySpawnerMobs()) {
 
             if (this.world.getDifficulty() != EnumDifficulty.PEACEFUL) {
 
@@ -206,9 +233,13 @@ public class TGSpawnerTileEnt extends BasicTGTileEntity implements ITickable {
                 double d2 = (double) blockpos.getZ() + (rand.nextDouble() - rand.nextDouble()) * this.spawnrange + 0.5D;
                 Entity entity = AnvilChunkLoader.readWorldEntityPos(entdata.getNbt(), world, d0, d1, d2, false);
 
-                if (entity instanceof ITGSpawnerNPC && entity instanceof EntityLiving) {
-                    ITGSpawnerNPC npc = (ITGSpawnerNPC) entity;
+                if (entity instanceof EntityLiving) {
                     EntityLiving elb = (EntityLiving) entity;
+                    boolean isTgNpc = entity instanceof ITGSpawnerNPC;
+                    if (!isTgNpc && !TGConfig.spawnerBlock.spawnerBlockUseCustomEntitySpawn) {
+                        this.delay = this.spawndelay;
+                        return;
+                    }
 
                     //  if (net.minecraftforge.event.ForgeEventFactory.canEntitySpawnSpawner(npc, this.world, (float)entity.posX, (float)entity.posY, (float)entity.posZ))
                     //  {
@@ -228,10 +259,19 @@ public class TGSpawnerTileEnt extends BasicTGTileEntity implements ITickable {
 
                         elb.spawnExplosionParticle();
 
-                        this.activeMobs.add(npc);
                         this.delay = this.spawndelay;
-                        TGSpawnerNPCData dat = TGSpawnerNPCData.get(npc);
-                        dat.setSpawnerPos(blockpos);
+                        if (isTgNpc) {
+                            ITGSpawnerNPC npc = (ITGSpawnerNPC) entity;
+                            this.activeMobs.add(npc);
+                            TGSpawnerNPCData dat = TGSpawnerNPCData.get(npc);
+                            if (dat != null) {
+                                dat.setSpawnerPos(blockpos);
+                            }
+                        } else {
+                            // Non-TG mobs don't have relink/death callbacks, so consume a spawn immediately.
+                            this.mobsLeft--;
+                            this.markDirty();
+                        }
                     }
                     //}
 

--- a/src/main/java/techguns/tileentities/TGSpawnerTileEnt.java
+++ b/src/main/java/techguns/tileentities/TGSpawnerTileEnt.java
@@ -11,23 +11,29 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ITickable;
 import net.minecraft.util.WeightedRandom;
 import net.minecraft.util.WeightedSpawnerEntity;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.chunk.storage.AnvilChunkLoader;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
 import org.jetbrains.annotations.NotNull;
+import techguns.TGConfig;
 import techguns.capabilities.TGSpawnerNPCData;
 import techguns.entities.npcs.ITGSpawnerNPC;
 
 import java.util.*;
 
 public class TGSpawnerTileEnt extends BasicTGTileEntity implements ITickable {
+    /**
+     * Radius (in blocks) used to scan nearby mobs and count only those linked to this spawner.
+     */
+    protected static final double SPAWNER_MOB_COUNT_RADIUS_BLOCKS = 24.0D;
 
     protected Random rand = new Random();
-    protected int delay = 200;
-    protected int spawndelay = 200;
-    protected int mobsLeft = 5;
-    protected int maxActive = 3;
+    protected int delay;
+    protected int spawndelay;
+    protected int mobsLeft;
+    protected int maxActive;
 
     protected int spawnHeightOffset = 0;
 
@@ -43,6 +49,12 @@ public class TGSpawnerTileEnt extends BasicTGTileEntity implements ITickable {
     public TGSpawnerTileEnt() {
         super(false);
         //this.addMobType(ZombieSoldier.class, 100);
+
+        int ticks = TGConfig.getSpawnerBlockIntervalTicks();
+        this.delay = ticks;
+        this.spawndelay = ticks;
+        this.mobsLeft = Math.max(1, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal);
+        this.maxActive = Math.max(1, Math.min(TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, this.mobsLeft));
     }
 
     public <T extends EntityLiving & ITGSpawnerNPC> void addMobType(Class<T> clazz, int weight) {
@@ -125,7 +137,7 @@ public class TGSpawnerTileEnt extends BasicTGTileEntity implements ITickable {
         this.delay = compound.getShort("delay");
         this.spawndelay = compound.getShort("spawnDelay");
         if (spawndelay < 1) {
-            spawndelay = 200;
+            spawndelay = TGConfig.getSpawnerBlockIntervalTicks();
         }
         this.maxActive = compound.getShort("maxActive");
         if (maxActive < 1) {
@@ -164,11 +176,24 @@ public class TGSpawnerTileEnt extends BasicTGTileEntity implements ITickable {
         return this.mobtypes.size() > 0;
     }
 
+    protected boolean hasTooManyNearbySpawnerMobs() {
+        BlockPos pos = this.getPos();
+        AxisAlignedBB area = new AxisAlignedBB(pos).grow(SPAWNER_MOB_COUNT_RADIUS_BLOCKS);
+        List<EntityLiving> mobs = this.world.getEntitiesWithinAABB(EntityLiving.class, area, e -> {
+            if (!(e instanceof ITGSpawnerNPC)) {
+                return false;
+            }
+            TGSpawnerNPCData dat = TGSpawnerNPCData.get((ITGSpawnerNPC) e);
+            return dat != null && pos.equals(dat.getSpawnerPos());
+        });
+        return mobs.size() >= TGConfig.spawnerBlock.spawnerBlockMaxLinkedMobs;
+    }
+
     @Override
     public void update() {
         if (this.world.isRemote) return;
         this.delay--;
-        if (this.delay <= 0 && activeMobs.size() < Math.min(maxActive, mobsLeft) && this.hasMobTypes()) {
+        if (this.delay <= 0 && activeMobs.size() < Math.min(maxActive, mobsLeft) && this.hasMobTypes() && !this.hasTooManyNearbySpawnerMobs()) {
 
             if (this.world.getDifficulty() != EnumDifficulty.PEACEFUL) {
 

--- a/src/main/java/techguns/world/dungeon/presets/PresetCastle.java
+++ b/src/main/java/techguns/world/dungeon/presets/PresetCastle.java
@@ -95,7 +95,7 @@ public class PresetCastle implements IDungeonPreset {
 
     @Override
     public void initSpawner(TGSpawnerTileEnt spawner) {
-        spawner.setParams(2, 2, 200, 2);
+        spawner.setParams(TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 2);
         spawner.addMobType(ZombieSoldier.class, 1);
         spawner.addMobType(SkeletonSoldier.class, 1);
     }

--- a/src/main/java/techguns/world/dungeon/presets/PresetNetherDungeonUnderground.java
+++ b/src/main/java/techguns/world/dungeon/presets/PresetNetherDungeonUnderground.java
@@ -78,7 +78,7 @@ public class PresetNetherDungeonUnderground implements IDungeonPreset {
 
     @Override
     public void initSpawner(TGSpawnerTileEnt spawner) {
-        spawner.setParams(2, 2, 200, 2);
+        spawner.setParams(TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 2);
         spawner.addMobType(ZombieSoldier.class, 1);
         spawner.addMobType(SkeletonSoldier.class, 1);
     }

--- a/src/main/java/techguns/world/dungeon/presets/PresetTechFortress.java
+++ b/src/main/java/techguns/world/dungeon/presets/PresetTechFortress.java
@@ -3,6 +3,7 @@ package techguns.world.dungeon.presets;
 import java.util.ArrayList;
 import java.util.Random;
 
+import techguns.TGConfig;
 import techguns.entities.npcs.StormTrooper;
 import techguns.tileentities.TGSpawnerTileEnt;
 import techguns.world.dungeon.DungeonSegment;
@@ -63,7 +64,7 @@ public class PresetTechFortress implements IDungeonPreset{
 
 	@Override
 	public void initSpawner(TGSpawnerTileEnt spawner) {
-		spawner.setParams(2, 2, 200, 2);
+		spawner.setParams(TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 2);
 		spawner.addMobType(StormTrooper.class, 1);
 	}
 

--- a/src/main/java/techguns/world/dungeon/presets/PresetTemplateTest.java
+++ b/src/main/java/techguns/world/dungeon/presets/PresetTemplateTest.java
@@ -1,5 +1,6 @@
 package techguns.world.dungeon.presets;
 
+import techguns.TGConfig;
 import techguns.entities.npcs.ZombieSoldier;
 import techguns.tileentities.TGSpawnerTileEnt;
 import techguns.world.dungeon.DungeonSegment;
@@ -38,7 +39,7 @@ public class PresetTemplateTest implements IDungeonPreset{
 
 	@Override
 	public void initSpawner(TGSpawnerTileEnt spawner) {
-		spawner.setParams(2, 1, 200, 2);
+		spawner.setParams(TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 2);
 		spawner.addMobType(ZombieSoldier.class, 1);
 	}
 

--- a/src/main/java/techguns/world/dungeon/presets/specialblocks/MBlockTGSpawner.java
+++ b/src/main/java/techguns/world/dungeon/presets/specialblocks/MBlockTGSpawner.java
@@ -8,6 +8,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import techguns.TGBlocks;
+import techguns.TGConfig;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.entities.npcs.SkeletonSoldier;
 import techguns.entities.npcs.ZombieSoldier;
@@ -16,9 +17,13 @@ import techguns.util.MBlock;
 
 public class MBlockTGSpawner extends MBlock {
 
-    protected int mobsleft = 5;
-    protected int maxActive = 2;
-    protected int spawndelay = 200;
+    /**
+     * 0 / negative delay = use {@link TGConfig#getSpawnerBlockIntervalTicks()} at placement.
+     * Set by {@link #MBlockTGSpawner(MBlock)} copies from dungeon templates.
+     */
+    protected int mobsleft;
+    protected int maxActive;
+    protected int spawndelay = -1;
     protected int spawnrange = 2;
 
     protected ArrayList<Class> classes = new ArrayList<>();
@@ -58,7 +63,13 @@ public class MBlockTGSpawner extends MBlock {
         TileEntity tile = w.getTileEntity(p);
         if (tile instanceof TGSpawnerTileEnt spawner) {
 
-            spawner.setParams(mobsleft, maxActive, spawndelay, spawnrange);
+            int ml = this.mobsleft > 0 ? this.mobsleft : Math.max(1, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal);
+            int ma = this.maxActive > 0 ? this.maxActive : Math.max(1, Math.min(TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, ml));
+            if (ma > ml) {
+                ma = ml;
+            }
+            int ticks = this.spawndelay >= 0 ? this.spawndelay : TGConfig.getSpawnerBlockIntervalTicks();
+            spawner.setParams(ml, ma, ticks, spawnrange);
 
             if (!this.weaponOverride.isEmpty()) {
                 spawner.setWeaponOverride(weaponOverride);

--- a/src/main/java/techguns/world/structures/AircraftCarrier.java
+++ b/src/main/java/techguns/world/structures/AircraftCarrier.java
@@ -65,8 +65,8 @@ public class AircraftCarrier extends WorldgenStructure {
 		blockList.add(new MBlockChestLoottable(Blocks.CHEST,3,LOOT_TABLE));//TGBlocks.tgchest, 3, true, BlockType.CHEST));
 		blockList.add(MBlockRegister.TECHNICAL2_FAN);//new MBlock(ChiselBlocks.technical2, 1));
 		blockList.add(new MBlockChestLoottable(Blocks.CHEST,4,LOOT_TABLE));//TGBlocks.tgchest, 4, true, BlockType.CHEST));
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,6,2,150,2).addMobType(ArmySoldier.class, 1).addMobType(Commando.class, 1));
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.SOLDIER_SPAWN,2,2,100,0).addMobType(AttackHelicopter.class, 1));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 2).addMobType(ArmySoldier.class, 1).addMobType(Commando.class, 1));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.SOLDIER_SPAWN, 1, 1, TGConfig.getSpawnerBlockIntervalTicks(), 0).addMobType(AttackHelicopter.class, 1));
 		blockList.add(MBlockRegister.SUPPLY_CRATES_CHANCE);
 		blocks = BlockUtils.loadStructureFromFile("aircraft_carrier");
 	}

--- a/src/main/java/techguns/world/structures/AlienBugNest.java
+++ b/src/main/java/techguns/world/structures/AlienBugNest.java
@@ -10,6 +10,7 @@ import net.minecraft.util.math.BlockPos.MutableBlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import techguns.TGBlocks;
+import techguns.TGConfig;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.blocks.EnumTGSandHardTypes;
 import techguns.blocks.EnumTGSlimyType;
@@ -40,7 +41,7 @@ public class AlienBugNest {
 		wallBlock2 = new MultiMBlock(new Block[]{TGBlocks.SAND_HARD, Blocks.SANDSTONE}, new int[]{EnumTGSandHardTypes.BUGNEST_SAND.ordinal(),0}, new int[]{12,1});
 		innerBlock = new MBlock(Blocks.AIR,0);
 	    slimyBlock = new MBlockSlime(TGBlocks.SAND_HARD, EnumTGSandHardTypes.BUGNEST_SAND.ordinal());
-	    spawner = new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, 7, 3, 150, 1).addMobType(AlienBug.class,	1);
+		spawner = new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(AlienBug.class, 1);
 	    eggsBlock = new MBlock(TGBlocks.SLIMY_BLOCK, EnumTGSlimyType.BUGNEST_EGGS.ordinal());
 		
 	}

--- a/src/main/java/techguns/world/structures/DesertOilCluster.java
+++ b/src/main/java/techguns/world/structures/DesertOilCluster.java
@@ -7,6 +7,7 @@ import java.util.Random;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import techguns.TGBlocks;
+import techguns.TGConfig;
 import techguns.TGFluids;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.blocks.EnumOreClusterType;
@@ -46,7 +47,7 @@ public class DesertOilCluster extends WorldgenStructure {
 		blockList.add(new MBlock(Blocks.SANDSTONE,0));
 		blockList.add(new MBlock(TGBlocks.SANDBAGS,0));
 		blockList.add(new MBlock(Blocks.AIR,0));
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.SOLDIER_SPAWN,3,1,200,1).addMobType(ArmySoldier.class, 4).addMobType(Commando.class, 1));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.SOLDIER_SPAWN, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(ArmySoldier.class, 4).addMobType(Commando.class, 1));
 		blockList.add(oilblockSand);
 		blockList.add(new MBlockOreclusterType(types, clusterWeights, 0.5f, ores));
 		blockList.add(oilblock);

--- a/src/main/java/techguns/world/structures/EndBuilding.java
+++ b/src/main/java/techguns/world/structures/EndBuilding.java
@@ -5,6 +5,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
+import techguns.TGConfig;
 import techguns.Tags;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.entities.npcs.Outcast;
@@ -43,7 +44,7 @@ public class EndBuilding extends WorldgenStructure {
         blockList.add(new MBlock("minecraft:purpur_block", 0));
         blockList.add(new MBlock("minecraft:purpur_stairs", 7));
         blockList.add(new MBlock("minecraft:stained_hardened_clay", 11));
-        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, 6, 2, 120, 1).addMobType(SuperMutantElite.class, 20).addMobType(Outcast.class, 20));
+        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(SuperMutantElite.class, 20).addMobType(Outcast.class, 20));
         blockList.add(new MBlock("minecraft:purpur_stairs", 6));
         blockList.add(new MBlock("minecraft:purpur_slab", 0));
         blockList.add(new MBlock("minecraft:purpur_stairs", 0));

--- a/src/main/java/techguns/world/structures/EndCluster.java
+++ b/src/main/java/techguns/world/structures/EndCluster.java
@@ -2,6 +2,7 @@ package techguns.world.structures;
 
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
+import techguns.TGConfig;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.entities.npcs.StormTrooper;
 import techguns.entities.npcs.SuperMutantElite;
@@ -20,7 +21,7 @@ public class EndCluster extends WorldgenStructure {
     static {
         blockList.add(new MBlock("minecraft:end_stone", 0));
         blockList.add(new MBlock("techguns:basicore", 4));
-        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, 6, 3, 100, 0).addMobType(StormTrooper.class, 20).addMobType(SuperMutantElite.class, 40));
+        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 0).addMobType(StormTrooper.class, 20).addMobType(SuperMutantElite.class, 40));
         blockList.add(new MBlock("techguns:orecluster", 4));
 
         blocks = BlockUtils.loadStructureFromFile("end_cluster");

--- a/src/main/java/techguns/world/structures/EndFloatingShip.java
+++ b/src/main/java/techguns/world/structures/EndFloatingShip.java
@@ -5,6 +5,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
+import techguns.TGConfig;
 import techguns.Tags;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.entities.npcs.Commando;
@@ -44,7 +45,7 @@ public class EndFloatingShip extends WorldgenStructure {
         blockList.add(new MBlock("minecraft:purpur_stairs", 2));
         blockList.add(new MBlock("techguns:neonlights", 0));
         blockList.add(new MBlock("minecraft:purpur_stairs", 1));
-        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, 6, 2, 120, 1).addMobType(DictatorDave.class, 2).addMobType(Outcast.class, 20).addMobType(Commando.class, 13));
+        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(DictatorDave.class, 2).addMobType(Outcast.class, 20).addMobType(Commando.class, 13));
         blockList.add(new MBlock("minecraft:purpur_pillar", 8));
         blockList.add(new MBlock("minecraft:purpur_block", 0));
         blockList.add(new MBlock("minecraft:purpur_pillar", 0));

--- a/src/main/java/techguns/world/structures/FactoryBig.java
+++ b/src/main/java/techguns/world/structures/FactoryBig.java
@@ -37,7 +37,7 @@ public class FactoryBig extends WorldgenStructure {
         blockList.add(new MBlock("techguns:stairs_concrete", 0));
         blockList.add(new MBlock("techguns:stairs_concrete", 3));
         blockList.add(new MBlock("techguns:stairs_concrete", 2));
-        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,6,2,150,2).addMobType(Bandit.class, 1).addMobType(Commando.class, 1));
+        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 2).addMobType(Bandit.class, 1).addMobType(Commando.class, 1));
         blockList.add(new MBlock("techguns:stairs_concrete", 4));
         blockList.add(new MBlock("techguns:metalpanel", 7));
         blockList.add(new MBlock("techguns:stairs_concrete", 6));

--- a/src/main/java/techguns/world/structures/FactoryHouseBig.java
+++ b/src/main/java/techguns/world/structures/FactoryHouseBig.java
@@ -36,7 +36,7 @@ public class FactoryHouseBig extends WorldgenStructure {
         blockList.add(new MBlock("minecraft:hardened_clay", 0));
         blockList.add(new MBlock("techguns:lamp0", 4));
         blockList.add(new MBlock("techguns:bunkerdoor", 1));
-        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,6,2,100,2).addMobType(ZombieMiner.class, 1).addMobType(ZombieSoldier.class, 1));
+        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 2).addMobType(ZombieMiner.class, 1).addMobType(ZombieSoldier.class, 1));
         blockList.add(new MBlock("minecraft:crafting_table", 0));
         blockList.add(new MBlock("techguns:bunkerdoor", 9));
         blockList.add(new MBlock("techguns:lamp0", 2));

--- a/src/main/java/techguns/world/structures/FactoryHouseSmall.java
+++ b/src/main/java/techguns/world/structures/FactoryHouseSmall.java
@@ -47,7 +47,7 @@ public class FactoryHouseSmall extends WorldgenStructure{
 		blockList.add(new MBlock(TGBlocks.LADDER_0.getDefaultState().withProperty(BlockTGLadder.FACING, EnumFacing.SOUTH)));
 		blockList.add(new MBlock(Blocks.IRON_BARS,0));//ChiselBlocks.iron_bars, 6));
 		blockList.add(new MBlock(TGBlocks.LAMP_0, EnumFacing.WEST.ordinal()));
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,5,2,150,2).addMobType(ZombieMiner.class, 1));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 2).addMobType(ZombieMiner.class, 1));
 		
 		blocks = BlockUtils.loadStructureFromFile("factory_building_small");
 

--- a/src/main/java/techguns/world/structures/GasStation.java
+++ b/src/main/java/techguns/world/structures/GasStation.java
@@ -42,7 +42,7 @@ private static final ResourceLocation CHEST_LOOT = new ResourceLocation(Tags.MOD
 		blockList.add(new MBlock("techguns:lamp0", 7));
 		blockList.add(new MBlock("minecraft:double_stone_slab", 0));
 		blockList.add(new MBlock("minecraft:stone_slab", 8));
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,3,2,200,1).addMobType(ZombieSoldier.class, 1).addMobType(ZombieFarmer.class, 1).addMobType(ZombieMiner.class, 1));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(ZombieSoldier.class, 1).addMobType(ZombieFarmer.class, 1).addMobType(ZombieMiner.class, 1));
 		blockList.add(new MBlock("minecraft:trapdoor", 10));
 		blockList.add(new MBlock("minecraft:trapdoor", 14));
 		blockList.add(new MBlock("minecraft:planks", 0));

--- a/src/main/java/techguns/world/structures/MilitaryCamp.java
+++ b/src/main/java/techguns/world/structures/MilitaryCamp.java
@@ -10,6 +10,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos.MutableBlockPos;
 import net.minecraft.world.World;
 import techguns.TGBlocks;
+import techguns.TGConfig;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.entities.npcs.ArmySoldier;
 import techguns.entities.npcs.AttackHelicopter;
@@ -219,7 +220,7 @@ public class MilitaryCamp {
         TileEntity tile = world.getTileEntity(p);
         if (tile instanceof TGSpawnerTileEnt spawner) {
             spawner.addMobType(AttackHelicopter.class, 1);
-            spawner.setParams(1, 1, 200, 0);
+            spawner.setParams(1, 1, TGConfig.getSpawnerBlockIntervalTicks(), 0);
 
             int h = Math.min(posY + 64, world.getActualHeight()) - posY;
             spawner.setSpawnHeightOffset(h);
@@ -237,7 +238,7 @@ public class MilitaryCamp {
             tile = world.getTileEntity(p);
             if (tile instanceof TGSpawnerTileEnt spawner) {
                 spawner.addMobType(ArmySoldier.class, 1);
-                spawner.setParams(3, 1, 200, 0);
+                spawner.setParams(3, 1, TGConfig.getSpawnerBlockIntervalTicks(), 0);
             }
         }
 

--- a/src/main/java/techguns/world/structures/NetherAltarMedium.java
+++ b/src/main/java/techguns/world/structures/NetherAltarMedium.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import techguns.TGBlocks;
+import techguns.TGConfig;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.entities.npcs.CyberDemon;
 import techguns.util.BlockUtils;
@@ -27,7 +28,7 @@ public class NetherAltarMedium extends WorldgenStructure {
 		blockList.add(new MBlock(TGBlocks.NETHER_METAL, 7));
 		blockList.add(new MBlock(TGBlocks.NETHER_METAL, 9));
 		blockList.add(new MBlock(Blocks.NETHER_BRICK_STAIRS, 0));
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,3,1,200,1).addMobType(CyberDemon.class, 1));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(CyberDemon.class, 1));
 		blockList.add(new MBlock(Blocks.NETHER_BRICK_STAIRS, 2));
 		blockList.add(new MBlock(Blocks.NETHER_BRICK_STAIRS, 3));
 		blockList.add(new MBlock(Blocks.NETHER_BRICK, 0));

--- a/src/main/java/techguns/world/structures/NetherAltarSmall.java
+++ b/src/main/java/techguns/world/structures/NetherAltarSmall.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import techguns.TGBlocks;
+import techguns.TGConfig;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.entities.npcs.CyberDemon;
 import techguns.util.BlockUtils;
@@ -26,7 +27,7 @@ public class NetherAltarSmall extends WorldgenStructure {
 		blockList.add(new MBlock(TGBlocks.NETHER_METAL, 7));
 		blockList.add(new MBlock(Blocks.NETHER_BRICK_STAIRS, 2));
 		blockList.add(new MBlock(Blocks.NETHER_BRICK_STAIRS, 3));
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,3,2,200,1).addMobType(CyberDemon.class, 1));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(CyberDemon.class, 1));
 		blockList.add(new MBlock(Blocks.NETHER_BRICK_STAIRS, 1));
 		
 		blocks = BlockUtils.loadStructureFromFile("nether_altar_small");

--- a/src/main/java/techguns/world/structures/NetherBuilding.java
+++ b/src/main/java/techguns/world/structures/NetherBuilding.java
@@ -3,6 +3,7 @@ package techguns.world.structures;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import techguns.TGConfig;
 import techguns.Tags;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.entities.npcs.CyberDemon;
@@ -68,7 +69,7 @@ public class NetherBuilding extends WorldgenStructure {
         blockList.add(new MBlock("minecraft:iron_door", 8));
         blockList.add(new MBlock("techguns:bunkerdoor", 8));
         blockList.add(new MBlock("techguns:lamp0", 2));
-        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.SOLDIER_SPAWN, 5, 2, 90, 0).addMobType(ZombiePigmanSoldier.class, 2).addMobType(StormTrooper.class, 1).addMobType(CyberDemon.class, 1));
+        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.SOLDIER_SPAWN, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 0).addMobType(ZombiePigmanSoldier.class, 2).addMobType(StormTrooper.class, 1).addMobType(CyberDemon.class, 1));
         blockList.add(new MBlock("techguns:stairs_metal", 13));
         blockList.add(new MBlockChestLoottable(Blocks.TRAPPED_CHEST, 3, CHEST_LOOT));
         blockList.add(new MBlock("techguns:ladder0", 11));

--- a/src/main/java/techguns/world/structures/NetherLoot01.java
+++ b/src/main/java/techguns/world/structures/NetherLoot01.java
@@ -30,7 +30,7 @@ public class NetherLoot01 extends WorldgenStructure {
 		blockList.add(new MBlock(Blocks.NETHERRACK, 0));
 		blockList.add(new MBlock(Blocks.SKULL, 1));
 		blockList.add(new MBlockChestLoottable(Blocks.CHEST, 5, CHEST_LOOT));
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,2,1,200,1).addMobType(ZombiePigmanSoldier.class, 1));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(ZombiePigmanSoldier.class, 1));
 		
 		blocks = BlockUtils.loadStructureFromFile("nether_loot_01");
 	}

--- a/src/main/java/techguns/world/structures/NetherOreClusterCastle.java
+++ b/src/main/java/techguns/world/structures/NetherOreClusterCastle.java
@@ -8,6 +8,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import techguns.TGBlocks;
+import techguns.TGConfig;
 import techguns.TGuns;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.entities.npcs.ZombiePigmanSoldier;
@@ -27,7 +28,7 @@ public class NetherOreClusterCastle extends WorldgenStructure {
 		blockList.add(MBlockRegister.AIR);
 		blockList.add(new MBlock(Blocks.NETHER_BRICK_FENCE, 0));
 		blockList.add(new MBlock(TGBlocks.NETHER_METAL, 6));
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,2,1,200,0).addMobType(ZombiePigmanSoldier.class, 1).setWeaponOverride(new ItemStack(TGuns.boltaction)));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 0).addMobType(ZombiePigmanSoldier.class, 1).setWeaponOverride(new ItemStack(TGuns.boltaction)));
 		blockList.add(new MultiMBlock(new Block[] {TGBlocks.ORE_CLUSTER, Blocks.AIR}, new int[] {7,0}, new int[] {40,60}));
 		blockList.add(new MBlock(TGBlocks.ORE_CLUSTER, 7));
 		

--- a/src/main/java/techguns/world/structures/NetherOreClusterMedium.java
+++ b/src/main/java/techguns/world/structures/NetherOreClusterMedium.java
@@ -3,6 +3,7 @@ package techguns.world.structures;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import techguns.TGConfig;
 import techguns.Tags;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.entities.npcs.CyberDemon;
@@ -34,7 +35,7 @@ public class NetherOreClusterMedium extends WorldgenStructure {
         blockList.add(new MBlock("techguns:metalpanel", 7));
         blockList.add(new MBlock("techguns:oredrill", 3));
         blockList.add(new MBlock("minecraft:glowstone", 0));
-        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, 4, 2, 80, 0).addMobType(CyberDemon.class, 30).addMobType(ZombiePigmanSoldier.class, 15).addMobType(StormTrooper.class, 10));
+        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 0).addMobType(CyberDemon.class, 30).addMobType(ZombiePigmanSoldier.class, 15).addMobType(StormTrooper.class, 10));
         blockList.add(new MBlock("techguns:orecluster", 7));
         blockList.add(new MBlock("techguns:oredrill", 2));
         blockList.add(new MBlock("techguns:concrete", 3));

--- a/src/main/java/techguns/world/structures/NetherSoulPlatform.java
+++ b/src/main/java/techguns/world/structures/NetherSoulPlatform.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import techguns.TGBlocks;
+import techguns.TGConfig;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.entities.npcs.Ghastling;
 import techguns.util.BlockUtils;
@@ -27,7 +28,7 @@ public class NetherSoulPlatform extends WorldgenStructure {
 		blockList.add(new MBlock(TGBlocks.NETHER_METAL, 7));
 		blockList.add(new MBlock(Blocks.GLOWSTONE, 0));
 		blockList.add(new MBlock(Blocks.NETHER_BRICK_FENCE, 0));
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,3,2,200,1).addMobType(Ghastling.class, 1));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(Ghastling.class, 1));
 		
 		blocks = BlockUtils.loadStructureFromFile("nether_soul_platform");
 	}

--- a/src/main/java/techguns/world/structures/NetherSubmarine.java
+++ b/src/main/java/techguns/world/structures/NetherSubmarine.java
@@ -6,6 +6,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
+import techguns.TGConfig;
 import techguns.Tags;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.entities.npcs.CyberDemon;
@@ -79,7 +80,7 @@ public class NetherSubmarine extends WorldgenStructure {
         blockList.add(new MBlockSkull(3, 1, "8e39ec3f-2af4-48d8-ae39-25e9b8561527", "uioz", "ewogICJ0aW1lc3RhbXAiIDogMTc2OTQyNTM2OTE1NCwKICAicHJvZmlsZUlkIiA6ICI4ZTM5ZWMzZjJhZjQ0OGQ4YWUzOTI1ZTliODU2MTUyNyIsCiAgInByb2ZpbGVOYW1lIiA6ICJ1aW96IiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2RiOWYwY2VjYjcxOTRkOTE0NzcwN2Q3YTU5NDM3YWM1ZWM4Nzc5MjFkNjVlOTFkZWYzZGVmYTlhNDQ2YWMwYjQiCiAgICB9CiAgfQp9"));
         blockList.add(new MBlock("minecraft:stone_slab", 0));
         blockList.add(new MBlock("techguns:stairs_metal", 10));
-        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.SOLDIER_SPAWN, 5, 2, 120, 0).addMobType(StormTrooper.class, 15).addMobType(CyberDemon.class, 5));
+        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.SOLDIER_SPAWN, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 0).addMobType(StormTrooper.class, 15).addMobType(CyberDemon.class, 5));
         blockList.add(new MBlock("minecraft:lever", 2));
         blockList.add(new MBlock("minecraft:stone_button", 2));
         blockList.add(new MBlock("techguns:ladder0", 4));

--- a/src/main/java/techguns/world/structures/OreClusterMeteorBasis.java
+++ b/src/main/java/techguns/world/structures/OreClusterMeteorBasis.java
@@ -8,6 +8,7 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import techguns.TGBlocks;
+import techguns.TGConfig;
 import techguns.blocks.EnumConcreteType;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.blocks.EnumOreClusterType;
@@ -45,7 +46,7 @@ public class OreClusterMeteorBasis extends WorldgenStructure {
 		blockList.add(new MBlock(TGBlocks.SANDBAGS, 0));
 		blockList.add(new MBlock(Blocks.IRON_BARS, 0));
 		blockList.add(new MBlock(Blocks.AIR, 0));
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,2,1,200,1).addMobType(ArmySoldier.class, 4).addMobType(Commando.class, 1));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(ArmySoldier.class, 4).addMobType(Commando.class, 1));
 		blockList.add(new MBlock(TGBlocks.METAL_PANEL, TGMetalPanelType.PANEL_LARGE_BORDER.ordinal()));
 		blockList.add(new MultiMBlock(new Block[] {Blocks.MAGMA, Blocks.STONE}, new int[]{0,0}, new int[]{1,1}));
 		blockList.add(new MBlock(TGBlocks.CONCRETE, EnumConcreteType.CONCRETE_BROWN_LIGHT_SCAFF.ordinal()));

--- a/src/main/java/techguns/world/structures/OreClusterSpike.java
+++ b/src/main/java/techguns/world/structures/OreClusterSpike.java
@@ -8,6 +8,7 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import techguns.TGBlocks;
+import techguns.TGConfig;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.blocks.EnumOreClusterType;
 import techguns.blocks.EnumOreType;
@@ -38,7 +39,7 @@ public class OreClusterSpike extends WorldgenStructure {
 	static {
 		Arrays.stream(clusterWeights).forEach(i -> totalweight+=i);
 		blockList.add(new MBlock(Blocks.AIR,0));
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,4,2,200,1).addMobType(AlienBug.class, 1));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(AlienBug.class, 1));
 		blockList.add(new MultiMBlock(new Block[] {Blocks.STONE, Blocks.AIR}, new int[] {0,0}, new int[] {1,1}));
 		blockList.add(new MBlock(TGBlocks.SLIMY_LADDER, 4));
 		blockList.add(new MBlock(TGBlocks.SLIMY_BLOCK, 0));

--- a/src/main/java/techguns/world/structures/PoliceStation.java
+++ b/src/main/java/techguns/world/structures/PoliceStation.java
@@ -36,7 +36,7 @@ public class PoliceStation extends WorldgenStructure {
 		blockList.add(MBlockRegister.OAK_PLANKS_1);
 		blockList.add(new MBlockChestLoottable(Blocks.CHEST, 2, CHEST_LOOT));
 		blockList.add(MBlockRegister.COBBLESTONE_7);
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.SOLDIER_SPAWN,3,1,200,1).addMobType(ZombiePoliceman.class, 1));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.SOLDIER_SPAWN, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(ZombiePoliceman.class, 1));
 		blockList.add(new MBlock(TGBlocks.LAMP_0, 7));
 		blockList.add(new MBlock(Blocks.RAIL, 6));
 		blockList.add(new MBlock(Blocks.RAIL, 9));

--- a/src/main/java/techguns/world/structures/SmallMine.java
+++ b/src/main/java/techguns/world/structures/SmallMine.java
@@ -8,6 +8,7 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import techguns.TGBlocks;
+import techguns.TGConfig;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.blocks.EnumOreClusterType;
 import techguns.blocks.EnumOreType;
@@ -53,7 +54,7 @@ public class SmallMine extends WorldgenStructure {
 		blockList.add(new MBlock(Blocks.TORCH, 4));
 		blockList.add(new MBlock(Blocks.TORCH, 2));
 		blockList.add(new MBlockOreClusterTypeOre(ores, oreWeights, new MBlock(Blocks.STONE,0),0.75f));
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,2,1,200,1).addMobType(ZombieMiner.class, 1));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(ZombieMiner.class, 1));
 		blockList.add(new MBlockOreclusterType(types, clusterWeights, 0.5f, ores));
 		blockList.add(new MBlockOreclusterType(types, clusterWeights, 0, null));
 	

--- a/src/main/java/techguns/world/structures/SmallTrainstation.java
+++ b/src/main/java/techguns/world/structures/SmallTrainstation.java
@@ -62,8 +62,8 @@ public class SmallTrainstation extends WorldgenStructure {
 		
 		//blockList.add(new MBlock(Block.getBlockFromName("tile.chisel.limestone_stairs.0"), 9));
 		blockList.add(MBlockRegister.STONEBRICK_STAIRS_WEST_CRACKED_RND); //new MultiMBlock(new Block[]{ChiselBlocks.limestoneStairs[0], ChiselBlocks.limestoneStairs[3], Blocks.AIR},new int[]{9,1,0}, new int[]{2,2,1}, new BlockType[]{BlockType.STAIRS2_CHISEL,BlockType.STAIRS, BlockType.TG}, new boolean[]{true,true,false}));
-		
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,3,2,200,1).addMobType(ZombieMiner.class, 1));
+
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(ZombieMiner.class, 1));
 		
 		blocks = BlockUtils.loadStructureFromFile("small_trainstation");
 	}

--- a/src/main/java/techguns/world/structures/SurvivorHideout.java
+++ b/src/main/java/techguns/world/structures/SurvivorHideout.java
@@ -34,7 +34,7 @@ private static final ResourceLocation CHEST_LOOT = new ResourceLocation(Tags.MOD
 		blockList.add(new MBlock(TGBlocks.LAMP_0, 12));
 		blockList.add(new MBlockChestLoottable(Blocks.CHEST, 2, CHEST_LOOT));
 		blockList.add(new MBlock("minecraft:stonebrick", 0));
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,3,2,200,1).addMobType(Bandit.class, 1));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(Bandit.class, 1));
 		blockList.add(new MBlock("minecraft:planks", 0));
 		blockList.add(new MBlockChestLoottable(Blocks.CHEST, 4, CHEST_LOOT));
 		blockList.add(new MBlock("minecraft:oak_stairs", 0));
@@ -46,7 +46,7 @@ private static final ResourceLocation CHEST_LOOT = new ResourceLocation(Tags.MOD
 		blockList.add(new MBlock("minecraft:bed", 2));
 		blockList.add(new MBlock("minecraft:torch", 1));
 		blockList.add(new MBlock("minecraft:crafting_table", 0));
-		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE,2,1,200,1).addMobType(Bandit.class, 1).setWeaponOverride(new ItemStack(TGuns.boltaction)));
+		blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 1).addMobType(Bandit.class, 1).setWeaponOverride(new ItemStack(TGuns.boltaction)));
 		blockList.add(new MBlock("minecraft:furnace", 3));
 		blockList.add(new MBlock("techguns:ladder0", 0));
 		blockList.add(new MBlock("techguns:simplemachine", 9));

--- a/src/main/java/techguns/world/structures/Train.java
+++ b/src/main/java/techguns/world/structures/Train.java
@@ -3,6 +3,7 @@ package techguns.world.structures;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import techguns.TGConfig;
 import techguns.Tags;
 import techguns.blocks.EnumMonsterSpawnerType;
 import techguns.entities.npcs.Bandit;
@@ -86,7 +87,7 @@ public class Train extends WorldgenStructure {
         blockList.add(new MBlock("techguns:sandbags", 0));
         blockList.add(new MBlock("minecraft:stone", 0));
         blockList.add(new MBlock("techguns:concrete", 1));
-        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, 8, 3, 100, 0).addMobType(Commando.class, 20).addMobType(Bandit.class, 40));
+        blockList.add(new MBlockTGSpawner(EnumMonsterSpawnerType.HOLE, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsTotal, TGConfig.spawnerBlock.spawnerBlockWorldgenMobsConcurrent, TGConfig.getSpawnerBlockIntervalTicks(), 0).addMobType(Commando.class, 20).addMobType(Bandit.class, 40));
         blockList.add(new MBlock("techguns:military_crate", 5));
         blockList.add(new MBlock("techguns:military_crate", 4));
         blockList.add(new MBlock("minecraft:iron_block", 0));


### PR DESCRIPTION
- Configuring the spawners via the config
- Ability to customize mobs in spawners (by editing NBT via other mods)
- New CraftTweaker methods for customizing weapons and armor
- Fixed incorrect stack upgrade usage in metal press (Ammo recipes with max upgrades)

CraftTweaker example:
```zenscript
mods.techguns.ArmorStats.setArmorDurability("t3_power_chestplate", 2400);
mods.techguns.ArmorStats.setArmorDisplayValue("t3_power_chestplate", 10);
mods.techguns.ArmorStats.setArmorKnockbackResistance("t3_power_chestplate", 0.35);
mods.techguns.ArmorStats.setArmorRadResistance("t3_power_chestplate", 1.0);
mods.techguns.ArmorStats.setArmorHiddenSlots("t3_power_chestplate", false, true, true);
mods.techguns.ArmorStats.setArmorRepairMats("t3_power_chestplate", <techguns:plate_carbon>, <techguns:circuit_board_elite>, 0.5, 4);
mods.techguns.ArmorStats.setPoweredArmorMaxPower("t3_power_chestplate", 10000);
mods.techguns.ArmorStats.setPoweredArmorBattery("t3_power_chestplate", <techguns:energy_cell>, <techguns:energy_cell_empty>);
mods.techguns.ArmorStats.setArmorStat("t3_power_chestplate", "SPEED", 0.08);

mods.techguns.ArmorStats.setMaterialBaseDurability("T3_POWER", 420);
mods.techguns.ArmorStats.setMaterialDurabilityFactor("T3_POWER", "CHEST", 0.35);
mods.techguns.ArmorStats.setMaterialToughness("T3_POWER", 3.0);
mods.techguns.ArmorStats.setMaterialArmorValue("T3_POWER", "PROJECTILE", 24.0);

mods.techguns.GunStats.setWeaponStat("ak47", "DAMAGE", 8.0);
mods.techguns.GunStats.setWeaponStat("ak47", "ACCURACY", 0.03);
mods.techguns.GunStats.setWeaponStat("ak47", "MIN_FIRE_TIME", 4);
mods.techguns.GunStats.setWeaponStat("ak47", "RELOAD_TIME", 38);
mods.techguns.GunStats.setWeaponDamageDrop("ak47", 18, 42, 5.5);
mods.techguns.GunStats.setWeaponZoom("ak47", 1.35, false, 0.7, false);
mods.techguns.GunStats.setWeaponHandType("ak47", "TWO_HANDED");
```