### PR TITLE
[BUGFIX] Try to fix Grinder recipes

### DIFF
--- a/src/main/java/techguns/items/guns/GenericGun.java
+++ b/src/main/java/techguns/items/guns/GenericGun.java
@@ -1669,4 +1669,9 @@ public class GenericGun extends GenericItem implements IGenericGun, IItemTGRende
     public void initModel() {
         ModelLoader.setCustomMeshDefinition(this, stack -> new ModelResourceLocation(getModelLocation(), "inventory"));
     }
+
+    @Override
+    public int getMetadata(@NotNull ItemStack stack) {
+        return 0;
+    }
 }


### PR DESCRIPTION
Старый баг (ещё с ванильного течганса), когда выпавшие с мобов пушки нельзя переработать в Измельчителе (aka Grinder). Происходило это из-за появляющейся ванильной прочности у пушки. Причину пофиксить не вышло, так чо я попробывал пофиксить сам рецепт.

## Вот хронология того, по какой причине Grinder не обрабатывает пушки с ванильной прочностью:
в GrinderTileEnt#checkAndStartOperation создаётся `MachineOperation`:
```java
MachineOperation op = GrinderRecipes.getOperationForInput(this.input.get(), this);
```
в GrinderRecipes этот метод выглядит так:
```java
public static MachineOperation getOperationForInput(ItemStack input, GrinderTileEnt tile) {
    for (GrinderRecipe r : recipes) {
        if (r.matchesInput(new ItemStackOreDict(input, 1))) {
            return r.getOperation(input, tile);
        }
    }
    return null;
}
```
метод проходится по всем рецептам и смотрит совпадают ли ItemStack в механизме и ItemStack в рецепте: `r.matchesInput(new ItemStackOreDict(input, 1))`. Этот метод выглядит так:
```java
public boolean matchesInput(ItemStackOreDict input) {
        return this.input.matches(input);
}
```
а в ItemStackOreDict метод выглядит так:
```java
public boolean matches(ItemStackOreDict other) {
    if (this.oreDictName != null && other.oreDictName != null) {
        return this.oreDictName.equals(other.oreDictName);
    } else if (this.oreDictName != null) {
        return this.isEqualWithOreDict(other.item);
    } else if (other.oreDictName != null) {
        return other.isEqualWithOreDict(this.item);
    } else {
        return OreDictionary.itemMatches(this.item, other.item, false);
    }
}
```
оредиктов у пушек нет, поэтому вызывается ванильный `OreDictionary#itemMatches`, он выглядит так:
```java
public static boolean itemMatches(@Nonnull ItemStack target, @Nonnull ItemStack input, boolean strict) {
    if (input.isEmpty() && !target.isEmpty() || !input.isEmpty() && target.isEmpty()) {
        return false;
    }
    return (target.getItem() == input.getItem() && ((target.getMetadata() == WILDCARD_VALUE && !strict) || target.getMetadata() == input.getMetadata()));
}
```
проверку на пустоту пропускаем, `item` одинаковый, а вот дальше сверяется метадата (обязательной проверкой через `&&`). 
В `ItemStack` метадата возвращается так:
```java
public int getMetadata() {
    return getItem().getMetadata(this);
}
```
а в `Item` так:
```java
public int getMetadata(ItemStack stack){
    return stack.itemDamage;
}
```
вот и наша прочность!

## Решение

Т.к. мы не можем убрать прочность при дропе с моба, мы можем попробывать игнорировать её, переопределив `getMetadata(ItemStack stack)` в `GenericGun`:
```java
@Override
public int getMetadata(@NotNull ItemStack stack) {
    return 0;
}
```
Именно это и делает этот PR

## P.s.
В теории эта правка не должна ничего ломать, однако я не смог провести корректный, потому что не смог воспроизвести этот баг в dev окружении (однако я, и не только я, встречался с ним в модпаках). Так что если кто-то сможет дать фитбек на этот фикс, будет здорово